### PR TITLE
Add Docker build and push action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# moduflow files
+.combined.md

--- a/docker-build-push/README.md
+++ b/docker-build-push/README.md
@@ -1,0 +1,91 @@
+# Docker Build and Push
+
+This action builds and pushes a Docker image to GitHub Container Registry (or other registries) upon merge to master/main branches. It's designed to be reusable across multiple projects.
+
+## Features
+
+- Automatic build and push to container registry
+- Customizable Docker image name and tags
+- Support for build arguments
+- Multiple tagging strategies (including commit SHA)
+- Uses Docker Buildx for optimized builds
+
+## Requirements
+
+- Repository needs `write` permission for the `packages` scope
+- GitHub token or Personal Access Token with appropriate permissions
+
+## Usage
+
+```yaml
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ master, main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      
+      - name: Build and push Docker image
+        uses: churnisa/actions/docker-build-push@master
+        with:
+          image-name: my-app
+```
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `image-name` | Name of the Docker image (without registry prefix) | Yes | - |
+| `dockerfile-path` | Path to the Dockerfile | No | `./Dockerfile` |
+| `build-context` | Docker build context | No | `.` |
+| `registry` | Container registry URL | No | `ghcr.io` |
+| `registry-username` | Username for registry authentication | No | `${{ github.actor }}` |
+| `registry-password` | Password for registry authentication | No | `${{ github.token }}` |
+| `tags` | Tags for the Docker image (comma-separated) | No | `latest` |
+| `build-args` | Build arguments for Docker build (JSON format) | No | `{}` |
+
+
+## Advanced Example
+
+See the [examples directory](./examples) for complete workflow examples.
+
+
+```yaml
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # Only push on merge to master/main, not on PRs
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Build and push Docker image
+        uses: churnisa/actions/docker-build-push@master
+        with:
+          image-name: my-api-service
+          dockerfile-path: './docker/Dockerfile.prod'
+          tags: 'latest,stable,${{ github.sha }}'
+          build-args: '{"NODE_ENV": "production", "API_VERSION": "1.2.3"}'
+```

--- a/docker-build-push/action.yaml
+++ b/docker-build-push/action.yaml
@@ -1,0 +1,73 @@
+name: Docker Build and Push
+description: Build a Docker image and push it to GitHub Container Registry upon merge to master
+
+inputs:
+  image-name:
+    description: "Name of the Docker image (without registry prefix)"
+    required: true
+  dockerfile-path:
+    description: "Path to the Dockerfile"
+    required: false
+    default: "./Dockerfile"
+  build-context:
+    description: "Docker build context"
+    required: false
+    default: "."
+  registry:
+    description: "Container registry URL"
+    required: false
+    default: "ghcr.io"
+  registry-username:
+    description: "Username for registry authentication"
+    required: false
+    default: "${{ github.actor }}"
+  registry-password:
+    description: "Password for registry authentication"
+    required: false
+    default: "${{ github.token }}"
+  tags:
+    description: "Tags for the Docker image (comma-separated)"
+    required: false
+    default: "latest"
+  build-args:
+    description: "Build arguments for Docker build (JSON format)"
+    required: false
+    default: "{}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry-username }}
+        password: ${{ inputs.registry-password }}
+        
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.image-name }}
+        tags: |
+          type=raw,value=${{ inputs.tags }}
+          type=sha,format=short
+          
+    - name: Parse build args
+      id: parse-build-args
+      shell: bash
+      run: |
+        echo "::set-output name=build_args::$(echo '${{ inputs.build-args }}' | jq -r 'to_entries | map("--build-arg \(.key)=\(.value)") | join(" ")')"
+        
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ inputs.build-context }}
+        file: ${{ inputs.dockerfile-path }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: ${{ steps.parse-build-args.outputs.build_args }}

--- a/docker-build-push/entrypoint.sh
+++ b/docker-build-push/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script is included for consistency with other actions, 
+# though the actual functionality is implemented via composite steps.
+# defined in action.yml
+
+echo "Using Docker Build and Push Action"
+echo "Image name: $INPUT_IMAGE_NAME"
+echo "Registry: $INPUT_REGISTRY"
+echo "Using Dockerfile at: $INPUT_DOCKERFILE_PATH"

--- a/docker-build-push/examples/workflow.yml
+++ b/docker-build-push/examples/workflow.yml
@@ -1,0 +1,27 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    branches: [ master, main ]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # Only push to registry on merge to master/main, not on PRs
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Build and push Docker image
+        uses: churnisa/actions/docker-build-push@master
+        with:
+          image-name: my-service
+          tags: 'latest,${{ github.sha }}'
+          build-args: '{"NODE_ENV": "production"}'


### PR DESCRIPTION
- Created reusable GitHub Action for building and pushing Docker images to container registries
- Supports customizable image names, tags, and build arguments
- Added comprehensive documentation with example workflow
- Added moduflow files to .gitignore
- Follows existing action structure for consistency