### PR TITLE
Fix deprecated set-output command in Docker build action

### DIFF
--- a/docker-build-push/action.yaml
+++ b/docker-build-push/action.yaml
@@ -60,7 +60,7 @@ runs:
       id: parse-build-args
       shell: bash
       run: |
-        echo "::set-output name=build_args::$(echo '${{ inputs.build-args }}' | jq -r 'to_entries | map("--build-arg \(.key)=\(.value)") | join(" ")')"
+        echo "build_args=$(echo '${{ inputs.build-args }}' | jq -r 'to_entries | map("--build-arg \(.key)=\(.value)") | join(" ")')" >> $GITHUB_OUTPUT
         
     - name: Build and push Docker image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
- Replaced deprecated '::set-output name=build_args::' syntax with the new echo "build_args=value" >> $GITHUB_OUTPUT syntax
- This addresses GitHub Actions deprecation warning for the set-output command